### PR TITLE
If next row starts with white-space - then it's considered part of th…

### DIFF
--- a/lib/streamLinesSubscriber.js
+++ b/lib/streamLinesSubscriber.js
@@ -4,7 +4,7 @@ module.exports = () => {
     return {
         subscribe: (stream, callback) => {
             stream
-                .pipe(split())
+                .pipe(split(/\r?\n(?!\s)/gms))
                 .on('data', callback)
         }
     }


### PR DESCRIPTION
…e last message. This solves this [issue](https://github.com/cshtdd/aws-cloudwatch-forwarder/issues/1)!

The user of this library should still replace each '\n' char with a '\n\t' string, but it should work now.

console.log(logRecord.split('\n').join('\n\t'))

